### PR TITLE
Refactor stats per unit

### DIFF
--- a/common.py
+++ b/common.py
@@ -15,8 +15,8 @@ def get_date_info():
     }
 
 
-URGENCY_LEVEL = { "NotUrgent": 1,
+URGENCY_LEVELS = {"NotUrgent": 1,
                   "LessUrgent": 2,
                   "Urgent": 3,
                   "Resuscitation": 4
-                 }
+                  }

--- a/data_processing.py
+++ b/data_processing.py
@@ -2,7 +2,7 @@
 This file handles the data processing necessary for the plots to function.
 It expects a hashed xlsx file, so run npr_hashing.py first.
 """
-from common import URGENCY_LEVEL, get_date_info
+from common import URGENCY_LEVELS, get_date_info
 
 import pandas as pd
 from pathlib import Path
@@ -24,9 +24,9 @@ def insert_triage_col(old_col):
         return False
 
     print(f"Mapping '{old_col}'.\n This might take some time ...")  # Console print
-    # Mapping old_col string values to URGENCY_LEVEL int counterpart, inserts col right of old original col
+    # Mapping old_col string values to URGENCY_LEVELS int counterpart, inserts col right of old original col
     new_col_index = df.columns.get_loc(old_col) + 1  # TODO: Test get_loc
-    mapped_urgency_values = df[old_col].map(URGENCY_LEVEL)
+    mapped_urgency_values = df[old_col].map(URGENCY_LEVELS)
     df.insert(new_col_index, new_col_name, mapped_urgency_values)
 
     print(f"Mapping complete: {mapped_urgency_values.count()} values mapped!") # Console print

--- a/metrics.py
+++ b/metrics.py
@@ -1,7 +1,7 @@
 """
 This file handles most of the metrics in the application - variable setting and user input functions.
 """
-from common import get_date_info
+from common import get_date_info, URGENCY_LEVELS
 import re
 import pandas as pd
 
@@ -11,10 +11,16 @@ import pandas as pd
 
 # -- DYNAMIC VALUES -- #
 
-def get_triage_stats_per_day(): # TODO: Create tests? Pytest
-    daily_patients_noturgent = df.loc[(df['Resultat av første triage'] == 'NotUrgent') & (df['Ankomst'].dt.date == )] # TODO: UNFINISHED
+def get_triage_stats_per_day(date) -> dict:  # TODO: Create tests? Pytest
+    patient_stats = {}
 
-
+    for level in URGENCY_LEVELS:
+        counter = df.loc[
+            (df['Resultat av første triage'] == level)
+            & (df['Ankomst'].dt.date == date.date())
+        ]
+        patient_stats[level] = len(counter)
+    return patient_stats
 
 # -- USER INPUTS -- #
 

--- a/metrics.py
+++ b/metrics.py
@@ -4,10 +4,7 @@ This file handles most of the metrics in the application - variable setting and 
 from common import get_date_info, URGENCY_LEVELS
 import re
 import pandas as pd
-
-
-
-
+import numpy as np
 
 # -- DYNAMIC VALUES -- #
 
@@ -21,6 +18,14 @@ def get_triage_stats_per_day(date) -> dict:  # TODO: Create tests? Pytest
         ]
         patient_stats[level] = len(counter)
     return patient_stats
+
+def dict_to_np_array(dict):
+    for key in dict:
+        key
+
+def triage_stats_per_hour(date) -> dict:
+    pass
+
 
 # -- USER INPUTS -- #
 

--- a/metrics.py
+++ b/metrics.py
@@ -8,23 +8,34 @@ import numpy as np
 
 # -- DYNAMIC VALUES -- #
 
-def get_triage_stats_per_day(date) -> dict:  # TODO: Create tests? Pytest
+def get_triage_stats_per_unit(date, datetime_prop='date') -> dict:  # TODO: Create tests? Pytest
     patient_stats = {}
 
-    for level in URGENCY_LEVELS:
-        counter = df.loc[
-            (df['Resultat av første triage'] == level)
-            & (df['Ankomst'].dt.date == date.date())
-        ]
-        patient_stats[level] = len(counter)
-    return patient_stats
+    if datetime_prop == 'hour':
+        for hour in range(24):
+            hourly_stats = {}
+            for level in URGENCY_LEVELS:
+                counter = df.loc[
+                    (df['Resultat av første triage'] == level)
+                    & (df['Ankomst'].dt.date == date.date())
+                    & (df['Ankomst'].dt.hour == hour)
+                ]
+                hourly_stats[level] = len(counter)
+            patient_stats[hour] = hourly_stats
+        return patient_stats
+
+    else:
+        for level in URGENCY_LEVELS:
+            counter = df.loc[
+                (df['Resultat av første triage'] == level)
+                & (df['Ankomst'].dt.date == date.date())
+            ]
+            patient_stats[level] = len(counter)
+        return patient_stats
 
 def dict_to_np_array(dict):
     for key in dict:
         key
-
-def triage_stats_per_hour(date) -> dict:
-    pass
 
 
 # -- USER INPUTS -- #

--- a/plots.py
+++ b/plots.py
@@ -1,8 +1,6 @@
 ﻿import matplotlib.pyplot as plt
 import numpy as np
-from data_processing import date_range
-from common import URGENCY_LEVELS
-
+from metrics import get_triage_stats_per_day
 # Stacked bar chart per day TODO: Decide if the data definition belongs here, or in data_processing
 hours_in_day = np.array([f"{hour:02d}" for hour in range(24)])
 

--- a/plots.py
+++ b/plots.py
@@ -1,7 +1,7 @@
 ﻿import matplotlib.pyplot as plt
 import numpy as np
 from data_processing import date_range
-from common import URGENCY_LEVEL
+from common import URGENCY_LEVELS
 
 # Stacked bar chart per day TODO: Decide if the data definition belongs here, or in data_processing
 hours_in_day = np.array([f"{hour:02d}" for hour in range(24)])


### PR DESCRIPTION
Refactored `get_triage_stats_per_day()` to `get_triage_stats_per_unit()`.

- Now takes in a second param - datetime_prop. Currently accepts 'date' or 'hour'.
- 'hour' param creates a nested dict of no. of patients per level per hour, to be used for stacked bar chart.
- Satisfying.